### PR TITLE
docs: add CDN installation option to README

### DIFF
--- a/.changeset/lazy-moons-destroy.md
+++ b/.changeset/lazy-moons-destroy.md
@@ -1,0 +1,5 @@
+---
+"requery-js": patch
+---
+
+docs: add cdn installation instructions to README.md

--- a/README.md
+++ b/README.md
@@ -20,8 +20,23 @@ ReQuery wouldn't exist without the Vue ecosystem. The reactive core is powered b
 
 ## Installation
 
+### NPM
+
 ```bash
 npm install requery-js
+```
+
+### CDN
+
+```html
+<script type="module">
+  import {
+    defineComponent,
+    queryComponent,
+  } from 'https://esm.run/requery-js@0';
+
+  // Your code here
+</script>
 ```
 
 ## Quick Start


### PR DESCRIPTION
Added CDN installation instructions alongside npm to provide multiple installation options for users.